### PR TITLE
Fix Jessie problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ FROM ruby:1.9.3
 #
 #  W: Failed to fetch http://http.debian.net/debian/dists/jessie-updates/InRelease
 #
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+RUN rm /etc/apt/sources.list
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian/ jessie main" >> /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list.d/jessie.list
 
 # Install the build essentials for building gems and the updated certificates
 # to prevent "certificate verify failed" errors.


### PR DESCRIPTION
### What
Fix issue with jessie dependency being downloaded from an archive repo with expired key

### What's the issue
When building the image, I was getting two errors:

1. `Step #0 - "Build": W: Failed to fetch http://security.debian.org/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]`
2. `Step #0 - "Build": W: Failed to fetch http://http.debian.net/debian/dists/jessie/main/binary-amd64/Packages  404  Not Found`

### Testing
I was able to build the repo locally successfully 

### Sources
1. [deb jessie](https://stackoverflow.com/questions/75836790/docker-packages-404-not-found-from-node8-jessie)
2. [trusted=yes](https://unix.stackexchange.com/questions/598344/debian-8-jessie-keyexpired-1587841717)
